### PR TITLE
性能优化

### DIFF
--- a/src/EasyFrameWork/Builder.cs
+++ b/src/EasyFrameWork/Builder.cs
@@ -58,7 +58,7 @@ namespace Easy
             services.TryAddTransient<IDataDictionaryService, DataDictionaryService>();
             services.TryAddTransient<ILanguageService, LanguageService>();
             services.TryAddTransient<IEncryptService, EncryptService>();
-            services.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            services.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
 
             services.AddTransient<IViewRenderService, ViewRenderService>();
             services.AddTransient<INotificationManager, NotificationManager>();
@@ -94,7 +94,7 @@ namespace Easy
 
             services.AddDataProtection();
 
-            services.AddDbContext<EasyDbContext>();
+            //services.AddDbContext<EasyDbContext>();
         }
 
         public static void ConfigureMetaData<TEntity, TMetaData>(this IServiceCollection service)

--- a/src/EasyFrameWork/EasyDbContext.cs
+++ b/src/EasyFrameWork/EasyDbContext.cs
@@ -10,7 +10,7 @@ namespace Easy
 {
     public class EasyDbContext : DbContextBase
     {
-        public EasyDbContext(IEnumerable<IOnModelCreating> modelCreatings, IOnDatabaseConfiguring configuring) : base(modelCreatings, configuring)
+        public EasyDbContext(DbContextOptions dbContextOptions) : base(dbContextOptions)
         {
         }
 

--- a/src/EasyFrameWork/Mvc/Plugin/Loader.cs
+++ b/src/EasyFrameWork/Mvc/Plugin/Loader.cs
@@ -18,7 +18,11 @@ namespace Easy.Mvc.Plugin
     {
         public const string PluginFolder = "Plugins";
         private const string PluginInfoFile = "zkea.plugin";
+#if DEBUG
         private string[] AltDevelopmentPath = new[] { "bin", "Debug", "netcoreapp2.1" };
+#else
+        private string[] AltDevelopmentPath = new[] { "bin", "Release", "netcoreapp2.1" };
+#endif
         private static List<AssemblyLoader> Loaders = new List<AssemblyLoader>();
         private static Dictionary<string, Assembly> LoadedAssemblies = new Dictionary<string, Assembly>();
         public Loader(IHostingEnvironment hostEnvironment)

--- a/src/EasyFrameWork/RepositoryPattern/DbContext.cs
+++ b/src/EasyFrameWork/RepositoryPattern/DbContext.cs
@@ -7,10 +7,8 @@ namespace Easy.RepositoryPattern
 {
     public class DbContextBase : DbContext
     {
-        public DbContextBase(IEnumerable<IOnModelCreating> modelCreatings, IOnDatabaseConfiguring configuring)
+        public DbContextBase(DbContextOptions dbContextOptions) : base(dbContextOptions)
         {
-            Creatings = modelCreatings;
-            DatabaseConfiguring = configuring;
         }
         public IEnumerable<IOnModelCreating> Creatings { get; set; }
         public IOnDatabaseConfiguring DatabaseConfiguring { get; set; }

--- a/src/EasyFrameWork/ResourcePool.cs
+++ b/src/EasyFrameWork/ResourcePool.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Easy
+{
+    //这个类支持实现这样一种“池”机制：
+    //当外部要获取一个资源时，首先尝试从“池”中获取，但如果从“池”创建的资源总数已经达到了一个限定值，
+    //则会按普通方式获取。
+    //池中对象是通过一个Scoped的ServiceProvider创建的，所以暂时不会被Dispose（因为那个Scope要到最后才Dispose），
+    //……
+    //曾经用这个类帮助实现了一个DbContext池（不同于EF提供的DbContextPool）。
+    //还可以稍作改进（去掉泛型类里面的IServiceGetter）……
+
+    public class ResourcePool
+    {
+        /// <summary>
+        /// 提供ServiceProvider
+        /// </summary>
+        public interface IServiceProviderProvider
+        {
+            IServiceProvider Provider { get; }
+        }
+    }
+    /// <summary>
+    /// 针对某个类型为T的资源的池
+    /// </summary>
+    /// <typeparam name="T">资源类型</typeparam>
+    public class ResourcePool<T> : ResourcePool, IDisposable where T : class
+    {
+        public interface IServiceGetter
+        {
+            T Get(IServiceProvider serviceProvider);
+        }
+        public class Options
+        {
+            public Options() { MaximumRetained = Environment.ProcessorCount * 2; }
+            public int MaximumRetained { get; set; }
+        }
+        public class ServiceGetter<TImplemention> : IServiceGetter where TImplemention : T
+        {
+            public T Get(IServiceProvider serviceProvider)
+            {
+                return serviceProvider.GetService<TImplemention>();
+            }
+        }
+        public interface ITransientResourceHolder : System.IDisposable
+        {
+            T Resource { get; }
+        }
+        class PooledObjectPolicy : PooledObjectPolicy<T>
+        {
+            public PooledObjectPolicy(IServiceScope serviceScope, int maximumRetained,
+                IServiceGetter serviceGetter)
+            {
+                _serviceScope = serviceScope;
+                _maximumRetained = maximumRetained;
+                _serviceGetter = serviceGetter;
+            }
+            readonly IServiceScope _serviceScope;
+            readonly int _maximumRetained;
+            readonly IServiceGetter _serviceGetter;
+            int _numObjectsInPool;
+            public override T Create()
+            {
+                if (System.Threading.Interlocked.Increment(ref _numObjectsInPool) > _maximumRetained)
+                {
+                    System.Threading.Interlocked.Decrement(ref _numObjectsInPool);
+                    return null;
+                }
+                var dbContext = _serviceGetter.Get(_serviceScope.ServiceProvider);
+                return dbContext;
+            }
+            public override bool Return(T obj)
+            {
+                return true;
+            }
+        }
+        public class TransientResourceHolder : ITransientResourceHolder
+        {
+            public TransientResourceHolder(ResourcePool<T> pool)
+            {
+                _pool = pool;
+                _resource = _pool._inner?.Get();
+                if (_resource != null)
+                {
+                    _resourceShouldReturnToPool = true;
+                }
+                else
+                {
+                    _resourceShouldReturnToPool = false;
+                    _resource = _pool._serviceGetter.Get(_pool._serviceProviderProvider.Provider);
+                }
+            }
+            public void Dispose()
+            {
+                if (_resourceShouldReturnToPool)
+                    _pool._inner.Return(_resource);
+            }
+            public T Resource { get { return _resource; } }
+            readonly ResourcePool<T> _pool;
+            readonly T _resource;
+            readonly bool _resourceShouldReturnToPool;
+        }
+        public ResourcePool(IServiceProviderProvider serviceProviderProvider, Options options,
+            IServiceGetter serviceGetter)
+        {
+            _serviceProviderProvider = serviceProviderProvider;
+            _serviceGetter = serviceGetter;
+            int maximumRetained = Math.Max(options.MaximumRetained, 0);
+            if (maximumRetained > 0)
+            {
+                _serviceScope = _serviceProviderProvider.Provider.CreateScope();
+                _pooledObjectPolicy = new PooledObjectPolicy(_serviceScope, maximumRetained, _serviceGetter);
+                _inner = new DefaultObjectPool<T>(_pooledObjectPolicy, maximumRetained);
+            }
+        }
+        public void Dispose()
+        {
+            if (_serviceScope != null)
+                _serviceScope.Dispose();
+        }
+        readonly IServiceProviderProvider _serviceProviderProvider;
+        readonly IServiceGetter _serviceGetter;
+        readonly IServiceScope _serviceScope;
+        readonly PooledObjectPolicy _pooledObjectPolicy;
+        readonly ObjectPool<T> _inner;
+    }
+}

--- a/src/EasyFrameWork/SimpleDbConnectionPool.cs
+++ b/src/EasyFrameWork/SimpleDbConnectionPool.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Data.Common;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Easy
+{
+    /// <summary>
+    /// 仅仅对单独一个数据库提供的连接池，对多个数据库的情形不支持
+    /// </summary>
+    public class SimpleDbConnectionPool : IDisposable
+    {
+        public class Options
+        {
+            public Options() { MaximumRetained = Environment.ProcessorCount * 2; }
+            public int MaximumRetained { get; set; }
+        }
+        class PooledObjectPolicy : PooledObjectPolicy<DbConnection>
+        {
+            internal PooledObjectPolicy(int maximumRetained, Func<DbConnection> funcCreateConnection)
+            {
+                _maximumRetained = maximumRetained;
+                _createdObjects = new DbConnection[_maximumRetained];
+                _funcCreateConnection = funcCreateConnection;
+            }
+            internal readonly DbConnection[] _createdObjects;
+            readonly int _maximumRetained;
+            readonly Func<DbConnection> _funcCreateConnection;
+            int _numObjectsInPool;
+
+            public override DbConnection Create()
+            {
+                var cnt = System.Threading.Interlocked.Increment(ref _numObjectsInPool);
+                if (cnt > _maximumRetained)
+                {
+                    System.Threading.Interlocked.Decrement(ref _numObjectsInPool);
+                    return null;
+                }
+                var dbConnection = _funcCreateConnection();
+                _createdObjects[cnt - 1] = dbConnection;
+                return dbConnection;
+            }
+            public override bool Return(DbConnection obj)
+            {
+                return true;
+            }
+        }
+        public class TransientObjectHolder : IDisposable
+        {
+            public TransientObjectHolder(SimpleDbConnectionPool pool)
+            {
+                _pool = pool;
+                _object = _pool._inner?.Get();
+                if (_object != null)
+                {
+                    _objectShouldReturnToPool = true;
+                }
+                else
+                {
+                    _object = _pool._funcCreateConnection();
+                    _objectShouldReturnToPool = false;
+                }
+                if (_object != null && _object.State == System.Data.ConnectionState.Closed)
+                {//预先打开数据库，为的是确保在使用EF的场合（比如ASP.Net）不会频繁打开/关闭数据库而致使性能下降
+                    _object.Open();
+                }
+            }
+            public void Dispose()
+            {
+                if (_object != null)
+                {
+                    if (_objectShouldReturnToPool)
+                        _pool._inner.Return(_object);
+                    else
+                        _object.Dispose();
+                    _object = null;
+                }
+            }
+            public DbConnection Object { get { return _object; } }
+            readonly SimpleDbConnectionPool _pool;
+            DbConnection _object;
+            readonly bool _objectShouldReturnToPool;
+        }
+        public SimpleDbConnectionPool(Options options, Func<DbConnection> funcCreateConnection)
+        {
+            _funcCreateConnection = funcCreateConnection;
+            int maximumRetained = Math.Max(options.MaximumRetained, 0);
+            if (maximumRetained > 0)
+            {
+                _pooledObjectPolicy = new PooledObjectPolicy(maximumRetained, _funcCreateConnection);
+                _inner = new DefaultObjectPool<DbConnection>(_pooledObjectPolicy, maximumRetained);
+            }
+        }
+        public void Dispose()
+        {
+            if (_pooledObjectPolicy != null)
+            {
+                var objects = _pooledObjectPolicy._createdObjects;
+                for (int i = 0; i < objects.Length; ++i)
+                {
+                    if (objects[i] != null)
+                    {
+                        objects[i].Dispose();
+                        objects[i] = null;
+                    }
+                }
+            }
+        }
+        readonly Func<DbConnection> _funcCreateConnection;
+        readonly PooledObjectPolicy _pooledObjectPolicy;
+        readonly ObjectPool<DbConnection> _inner;
+    }
+}

--- a/src/ZKEACMS.Article/ArticlePlug.cs
+++ b/src/ZKEACMS.Article/ArticlePlug.cs
@@ -120,7 +120,7 @@ namespace ZKEACMS.Article
             serviceCollection.AddTransient<IArticleTypeService, ArticleTypeService>();
             serviceCollection.AddTransient<IRouteDataProvider, ArticleRouteDataProvider>();
             serviceCollection.AddTransient<IRouteDataProvider, ArticleTypeRouteDataProvider>();
-            serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            serviceCollection.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
 
             serviceCollection.Configure<ArticleListWidget>(option =>
             {

--- a/src/ZKEACMS.FormGenerator/FormPlug.cs
+++ b/src/ZKEACMS.FormGenerator/FormPlug.cs
@@ -102,7 +102,7 @@ namespace ZKEACMS.FormGenerator
 
         public override void ConfigureServices(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            serviceCollection.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
 
             serviceCollection.AddTransient<IFormDataValidator, DateTimeFormDataValidator>();
             serviceCollection.AddTransient<IFormDataValidator, EmailFormDataValidator>();

--- a/src/ZKEACMS.Message/MessagePlug.cs
+++ b/src/ZKEACMS.Message/MessagePlug.cs
@@ -109,7 +109,7 @@ namespace ZKEACMS.Message
 
         public override void ConfigureServices(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            serviceCollection.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
 
             serviceCollection.AddTransient<IMessageService, MessageService>();
             serviceCollection.AddTransient<ICommentsService, CommentsService>();

--- a/src/ZKEACMS.Product/ProductPlug.cs
+++ b/src/ZKEACMS.Product/ProductPlug.cs
@@ -122,7 +122,7 @@ namespace ZKEACMS.Product
 
         public override void ConfigureServices(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            serviceCollection.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
             
             serviceCollection.AddTransient<IRouteDataProvider, ProductRouteDataProvider>();
             serviceCollection.AddTransient<IRouteDataProvider, ProductCategoryRouteDataProvider>();

--- a/src/ZKEACMS.Redirection/Controllers/UrlRedirectionController.cs
+++ b/src/ZKEACMS.Redirection/Controllers/UrlRedirectionController.cs
@@ -42,6 +42,11 @@ namespace ZKEACMS.Redirection.Controllers
         {
             return base.Index();
         }
+        public override IActionResult Delete(int id)
+        {
+            UrlRedirectService.InvalidateCachedItems();
+            return base.Delete(id);
+        }
         [DefaultAuthorize(Policy = PermissionKeys.ManageUrlRedirect)]
         public override IActionResult Edit(int Id)
         {
@@ -56,6 +61,7 @@ namespace ZKEACMS.Redirection.Controllers
                 {
                     return View(entity);
                 }
+                UrlRedirectService.InvalidateCachedItems();
                 return base.Edit(entity);
             }
             return View(entity);
@@ -74,6 +80,7 @@ namespace ZKEACMS.Redirection.Controllers
                 {
                     return View(entity);
                 }
+                UrlRedirectService.InvalidateCachedItems();
                 return base.Create(entity);
             }
             return View(entity);
@@ -90,7 +97,7 @@ namespace ZKEACMS.Redirection.Controllers
                 return RedirectPermanent($"~/{(path ?? "")}.html");
             }
             path = $"~/{(path ?? "").TrimEnd('/')}";
-            var redirec = Service.Get(m => m.InComingUrl == path).FirstOrDefault();
+            var redirec = UrlRedirectService.GetItems(() => Service).Where(m => m.InComingUrl == path).FirstOrDefault();
             if (redirec != null)
             {
                 if (redirec.IsPermanent)

--- a/src/ZKEACMS.Redirection/RedirectRouteConstraint.cs
+++ b/src/ZKEACMS.Redirection/RedirectRouteConstraint.cs
@@ -18,7 +18,7 @@ namespace ZKEACMS.Redirection
             {
                 return true;
             }
-            var redirect = httpContext.RequestServices.GetService<IUrlRedirectService>().Count(m => m.Status == (int)Easy.Constant.RecordStatus.Active && m.InComingUrl == path && m.InComingUrl != m.DestinationURL);
+            var redirect = UrlRedirectService.GetItems(()=>httpContext.RequestServices.GetService<IUrlRedirectService>()).Count(m => m.Status == (int)Easy.Constant.RecordStatus.Active && m.InComingUrl == path && m.InComingUrl != m.DestinationURL);
             return redirect > 0;
         }
     }

--- a/src/ZKEACMS.Redirection/RedirectionPlug.cs
+++ b/src/ZKEACMS.Redirection/RedirectionPlug.cs
@@ -77,7 +77,7 @@ namespace ZKEACMS.Redirection
 
         public override void ConfigureServices(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            serviceCollection.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
 
             serviceCollection.TryAddTransient<IUrlRedirectService, UrlRedirectService>();
 

--- a/src/ZKEACMS.Redirection/Service/UrlRedirectService.cs
+++ b/src/ZKEACMS.Redirection/Service/UrlRedirectService.cs
@@ -14,5 +14,26 @@ namespace ZKEACMS.Redirection.Service
         public UrlRedirectService(IApplicationContext applicationContext, CMSDbContext dbContext) : base(applicationContext, dbContext)
         {
         }
+        static List<UrlRedirect> _cachedItems;
+        static object _syncObject = new object();
+        public static void InvalidateCachedItems()
+        {
+            lock(_syncObject)
+            {
+                _cachedItems = null;
+            }
+        }
+        public static List<UrlRedirect> GetItems(Func<IUrlRedirectService> serviceGetter)
+        {
+            lock(_syncObject)
+            {
+                if (_cachedItems == null)
+                {
+                    var service = serviceGetter();
+                    _cachedItems = service.Get().ToList();
+                }
+                return _cachedItems;
+            }
+        }
     }
 }

--- a/src/ZKEACMS.SectionWidget/SectionPlug.cs
+++ b/src/ZKEACMS.SectionWidget/SectionPlug.cs
@@ -73,7 +73,7 @@ namespace ZKEACMS.SectionWidget
 
         public override void ConfigureServices(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            serviceCollection.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
 
             serviceCollection.AddTransient<ISectionGroupService, SectionGroupService>();
             serviceCollection.AddTransient<ISectionContentProviderService, SectionContentProviderService>();

--- a/src/ZKEACMS.Shop/ShopPlug.cs
+++ b/src/ZKEACMS.Shop/ShopPlug.cs
@@ -110,7 +110,7 @@ namespace ZKEACMS.Shop
 
         public override void ConfigureServices(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
+            serviceCollection.AddSingleton<IOnModelCreating, EntityFrameWorkModelCreating>();
 
             serviceCollection.TryAddTransient<IBasketService, BasketService>();
             serviceCollection.TryAddTransient<IOrderService, OrderService>();

--- a/src/ZKEACMS.WebHost/EntityFrameWorkConfigure.cs
+++ b/src/ZKEACMS.WebHost/EntityFrameWorkConfigure.cs
@@ -4,6 +4,7 @@
  * http://www.zkea.net/licenses
  */
 
+using System.Data.Common;
 using Easy.RepositoryPattern;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -13,37 +14,49 @@ using ZKEACMS.Options;
 
 namespace ZKEACMS.WebHost
 {
-    public class EntityFrameWorkConfigure : IOnDatabaseConfiguring
+    public class EntityFrameWorkConfigure
     {
-        private readonly IOptionsSnapshot<DatabaseOption> _dataBaseOption;
+        private readonly DatabaseOption _dataBaseOption;
         private readonly ILoggerFactory _loggerFactory;
-        public EntityFrameWorkConfigure(IOptionsSnapshot<DatabaseOption> dataBaseOption, ILoggerFactory loggerFactory)
+        public EntityFrameWorkConfigure(DatabaseOption dataBaseOption, ILoggerFactory loggerFactory)
         {
             _dataBaseOption = dataBaseOption;
             _loggerFactory = loggerFactory;
         }
-        public void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        public void OnConfiguring(DbContextOptionsBuilder optionsBuilder, DbConnection dbConnectionForReusing)
         {
-            switch (_dataBaseOption.Value.DbType)
+            switch (_dataBaseOption.DbType)
             {
                 case Easy.DbTypes.MsSql:
                     {
-                        optionsBuilder.UseSqlServer(_dataBaseOption.Value.ConnectionString);
+                        if (dbConnectionForReusing != null)
+                            optionsBuilder.UseSqlServer(dbConnectionForReusing);
+                        else
+                            optionsBuilder.UseSqlServer(_dataBaseOption.ConnectionString);
                         break;
                     }
                 case Easy.DbTypes.MsSqlEarly:
                     {
-                        optionsBuilder.UseSqlServer(_dataBaseOption.Value.ConnectionString, option => option.UseRowNumberForPaging());
+                        if (dbConnectionForReusing != null)
+                            optionsBuilder.UseSqlServer(dbConnectionForReusing);
+                        else
+                            optionsBuilder.UseSqlServer(_dataBaseOption.ConnectionString, option => option.UseRowNumberForPaging());
                         break;
                     }
                 case Easy.DbTypes.Sqlite:
                     {
-                        optionsBuilder.UseSqlite(_dataBaseOption.Value.ConnectionString);
+                        if (dbConnectionForReusing != null)
+                            optionsBuilder.UseSqlite(dbConnectionForReusing);
+                        else
+                            optionsBuilder.UseSqlite(_dataBaseOption.ConnectionString);
                         break;
                     }
                 case Easy.DbTypes.MySql:
                     {
-                        optionsBuilder.UseMySql(_dataBaseOption.Value.ConnectionString);
+                        if (dbConnectionForReusing != null)
+                            optionsBuilder.UseMySql(dbConnectionForReusing);
+                        else
+                            optionsBuilder.UseMySql(_dataBaseOption.ConnectionString);
                         break;
                     }
             }

--- a/src/ZKEACMS.WebHost/Startup.cs
+++ b/src/ZKEACMS.WebHost/Startup.cs
@@ -30,7 +30,106 @@ namespace ZKEACMS.WebHost
         {
             services.ConfigureResource<DefaultResourceManager>();
 
-            services.AddScoped<IOnDatabaseConfiguring, EntityFrameWorkConfigure>();
+            //services.AddScoped<IOnDatabaseConfiguring, EntityFrameWorkConfigure>();
+            //
+            services.AddSingleton<EntityFrameWorkConfigure>();
+            if (!true)
+            {//思路1：仅用DbContext池的模式
+                services.AddDbContextPool<CMSDbContext>((sp, optionsBuilder) =>
+                {
+                    var configure = sp.GetService<EntityFrameWorkConfigure>();
+                    configure.OnConfiguring(optionsBuilder, null);
+                }, 128);
+            }
+            else
+            {//思路2：仅用DbConnection池的模式
+                //
+                services.AddSingleton<Easy.SimpleDbConnectionPool>((sp) =>
+                {
+                    var option = sp.GetService<Options.DatabaseOption>();
+                    //此方法负责从数据库选项中创建数据库连接。
+                    //可返回null。
+                    //返回null时，就没有了“池”和“保持数据库打开”这两项好处。
+                    System.Func<System.Data.Common.DbConnection> funcCreateConnection = () =>
+                      {
+                          switch (option.DbType)
+                          {
+                              case Easy.DbTypes.MsSql:
+                                  return null;
+                              case Easy.DbTypes.MsSqlEarly:
+                                  return null;
+                              case Easy.DbTypes.Sqlite:
+                                  {
+                                      var result = new Microsoft.Data.Sqlite.SqliteConnection(option.ConnectionString);
+                                      result.Open();
+                                      //优化sqlite的用法
+                                      using (var cmd = result.CreateCommand())
+                                      {
+                                          cmd.CommandText = "pragma journal_mode=wal;";
+                                          cmd.CommandText += "pragma read_uncommitted=1;";
+                                          cmd.ExecuteNonQuery();
+                                      }
+                                      return result;
+                                  }
+                              case Easy.DbTypes.MySql:
+                                  return null;
+                          }
+                          return null;
+                      };
+                    var poolOptions = sp.GetService<Easy.SimpleDbConnectionPool.Options>();
+                    var pool = new Easy.SimpleDbConnectionPool(poolOptions, funcCreateConnection);
+                    return pool;
+                });
+                //池的配置：
+                //MaximumRetained规定池的容量（常态最大保有数量）。
+                //MaximumRetained为0时，相当于不使用DbConnection池，
+                //但因为在Request期间Connection是保持打开的，所以对许多场合还是有性能改善的。
+                services.AddSingleton(new Easy.SimpleDbConnectionPool.Options() { MaximumRetained = 128 });
+                //提供在Request期间租、还DbConnection的支持
+                services.AddScoped<Easy.SimpleDbConnectionPool.TransientObjectHolder>();
+
+                services.AddScoped<Microsoft.EntityFrameworkCore.DbContextOptions<CMSDbContext>>(sp =>
+                {
+                    //租一个DbConnection（将在Request完成后还回，因为其Lifetime为Scoped类型）
+                    var holder = sp.GetService<Easy.SimpleDbConnectionPool.TransientObjectHolder>();
+                    //
+                    var configure = sp.GetService<EntityFrameWorkConfigure>();
+                    var optBuilder = new Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<CMSDbContext>();
+                    configure.OnConfiguring(optBuilder, holder.Object);
+                    return optBuilder.Options;
+                });
+                services.AddDbContext<CMSDbContext>(ServiceLifetime.Scoped);
+            }
+            //思路3：
+            //同时用DbContext池和DbConnection池？
+            //应该是不可以的。
+            //原因：用DbConextPool时，各个DbContext应该是共用着同一个DbContextOptionsBuilder；
+            //我曾经想让某个DbContext使用“自己的”DbConnection，所以在OnConfiguring中修改了DbContextOptionsBuilder，
+            //但这导致EntityFramework中抛出异常，说是DbContex在支持Pool时，不允许修改DbContextOptionsBuilder。
+            //思路4：
+            //自己写DbContext池，不使用EntityFramework提供的DbContextPool？
+            //为什么自己写？自己写可以让池中的每个DbContext在Request结束时仍然保持DbConnection打开，
+            //而EF提供的DbContextPool，似乎预先打开Connection的“技巧”对它没用（没有查源码找原因和解决办法）。
+            //这个思路我试验过了。简单的测试证明，这个模式的性能是最好的。
+            //但是经过考虑，不推荐用这个思路，原因是：
+            //1）对现有代码的改动会稍微多一些；
+            //2）不确定在Request之间这么简单的重新利用DbConext会不会导致在有数据修改的情况下出现“错乱”的现象。
+            //（实际上即使没有数据修改时，也观察到了一个“错乱”：如果NavigationWidgetService里面不是对每个
+            //NavigationEntity的IsCurrent都重新赋值的话，页面上导航栏的显示就“乱”了。）而EF在使用DbContextPool
+            //的时候，肯定用了恰当的Reset动作。
+            //3）从使用场合考虑，思路1或思路2提供的性能够用了，而且实现上更为简单易懂。
+            //
+            //总结：
+            //1）探讨了几种性能改进思路，用sqlite数据库进行了简单测试对比。
+            //2）sqlite数据库因为自身没有连接池，所以要是实际应用的话，推荐用思路2优化性能。
+            //其它数据库本人未实测，但从原理来说，即便数据库自身有连接池，避免反复的打开、关闭也是有益的，
+            //在EntityFramework的在线文档中也为此提供了一些指导，因此，应用思路2应该“至少没有坏处”。
+            //只不过具体的性能改进程度，可能就比不上用sqlite的那种情况了。
+            //3）sqlite建库时，通常日志模式选择“WAL”时写入性能更好。为避免手动升级数据库，
+            //我在这里把它放到思路2的创建DbConnection后执行了。如果不用这个方式，建议在源代码库中把数据库修改一下。
+
+            services.AddScoped<EasyDbContext>((provider) => provider.GetService<CMSDbContext>());
+
             services.UseZKEACMS(Configuration);
         }
 

--- a/src/ZKEACMS/Builder.cs
+++ b/src/ZKEACMS/Builder.cs
@@ -156,9 +156,11 @@ namespace ZKEACMS
                 option.DataSourceLink = "~/admin/Carousel";
             });
 
-            services.AddDbContext<CMSDbContext>();
+            //services.AddDbContext<CMSDbContext>();
 
-            services.Configure<DatabaseOption>(configuration.GetSection("Database"));
+            var databaseOption = configuration.GetSection("Database").Get<Options.DatabaseOption>();
+            services.AddSingleton(databaseOption);
+            //services.Configure<DatabaseOption>(configuration.GetSection("Database"));
 
             services.UseEasyFrameWork(configuration);
             foreach (var item in services.LoadAvailablePlugins())

--- a/src/ZKEACMS/CMSDbContext.cs
+++ b/src/ZKEACMS/CMSDbContext.cs
@@ -21,8 +21,12 @@ namespace ZKEACMS
 {
     public class CMSDbContext : EasyDbContext
     {
-        public CMSDbContext(IEnumerable<IOnModelCreating> modelCreatings, IOnDatabaseConfiguring configuring) : base(modelCreatings, configuring)
+        public CMSDbContext(DbContextOptions<CMSDbContext> dbContextOptions) : base(dbContextOptions)
         {
+            var onModelCreateings = Easy.ServiceLocator.GetServices<IOnModelCreating>();
+            Creatings = onModelCreateings;
+            var databaseConfiguring = Easy.ServiceLocator.GetService<IOnDatabaseConfiguring>();
+            DatabaseConfiguring = databaseConfiguring;
         }
 
         internal DbSet<WidgetBasePart> WidgetBasePart { get; set; }

--- a/src/ZKEACMS/Constant.cs
+++ b/src/ZKEACMS/Constant.cs
@@ -124,11 +124,11 @@ namespace ZKEACMS
 
     public static class CustomRegex
     {
-        public static readonly Regex StyleRegex = new Regex(@"style=""([^""]*)""", RegexOptions.IgnoreCase);
+        public static readonly Regex StyleRegex = new Regex(@"style=""([^""]*)""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        public static Regex PostIdRegex = new Regex(@"/post-(\d+)", RegexOptions.IgnoreCase);
-        public static Regex CategoryIdRegex = new Regex(@"/cate-(\d+)", RegexOptions.IgnoreCase);
-        public static Regex PageRegex = new Regex(@"/p-(\d+)", RegexOptions.IgnoreCase);
+        public static Regex PostIdRegex = new Regex(@"/post-(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static Regex CategoryIdRegex = new Regex(@"/cate-(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public static Regex PageRegex = new Regex(@"/p-(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     }
     public static class Version
     {

--- a/src/ZKEACMS/ZKEACMS.csproj
+++ b/src/ZKEACMS/ZKEACMS.csproj
@@ -14,6 +14,9 @@
     <AssemblyVersion>3.1.0.0</AssemblyVersion>
     <FileVersion>3.1.0.0</FileVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyFrameWork\EasyFrameWork.csproj" />
   </ItemGroup>


### PR DESCRIPTION
主要优化：
    实现了数据库连接池以及在处理Request期间保持数据库连接是Open状态。
    详细说明见WebHost工程的Startup.cs。

---
其它小优化（可能看不出明显效果）：
1.正则表达式预编译：在ZKEACMS/Constant.cs里面，Regex对象构造时，添加了选项RegexOptions.Compiled。
2. 把所有的IOnModelCreating服务都改为了单件，比如原来是：
      serviceCollection.AddScoped<IOnModelCreating, EntityFrameWorkModelCreating>();
   则把 AddScoped 改为 AddSingleton
3. 使用IOptions<DatabaseOption>的地方，换成使用DatabaseOption，相应地，在Builder.cs里面，
       services.Configure<DatabaseOption>(configuration.GetSection("Database"));
   要改成：
       services.TryAddSingleton(configuration.GetSection("Database").Get<DatabaseOption>());
   （不过 DbUpdaterService 的代码没有跟着改，遇到问题再说吧）
4. 在ZKEACMS.Redirection中，缓存了数据库表记录，不需要每次都到数据库查，而是当被编辑的时候，使缓存无效。
5. 把sqlite数据库的日志模式设置为WAL：Pragma journal_mode=WAL
   (实际上，如果没有保持连接打开的话，原先是DELETE模式，这模式在打开数据库时很快，而WAL模式会慢许多，
   当然，这说的只是每次使用都要打开、关闭数据库连接并且只考虑了读取的情况。WAL模式更好，那是无疑的。)